### PR TITLE
OrderedDict to save gps

### DIFF
--- a/bleParking/forms.py
+++ b/bleParking/forms.py
@@ -3,6 +3,8 @@ from django import forms
 import datetime
 import json
 
+import logging
+logger = logging.getLogger('django')
 def is_json(myjson):
     try:
         json.loads(myjson)

--- a/bleParking/models.py
+++ b/bleParking/models.py
@@ -5,6 +5,7 @@ from .forms import ObjectListCharField,ObjectListFloatField,ObjectListParklotSta
 import datetime
 import re
 from bson.objectid import ObjectId
+import collections
 #from save_the_change.mixins import SaveTheChange
 from django.utils.translation import ugettext_lazy as _
 #add belows to rewrite update/save
@@ -167,11 +168,7 @@ class parklot(models.Model):
                 "city":self.addr.city,
                 "district":self.addr.district,
                 "street":self.addr.street,
-            },
-            "gps":{
-                "longitude":self.gps.longitude,
-                "latitude":self.gps.latitude,
-            },
+            }
         }
         #print "this***! " , self.status.free
         parklot = db.parklot
@@ -189,6 +186,10 @@ class parklot(models.Model):
                     "update_on":self.status.update_on,
                     "update_by": self.status.update_by,
                 }
+            if hasattr(self,'gps'):
+                current["gps"]=collections.OrderedDict()
+                current["gps"]["longitude"]=self.gps.longitude
+                current["gps"]["latitude"]=self.gps.latitude
 
             pre_id = parklot.insert_one(current).inserted_id
             # if not exist, insert and print id here, if true then success
@@ -203,6 +204,11 @@ class parklot(models.Model):
                     "update_on":self.status.update_on,
                     "update_by":self.status.update_by,
                 }
+            if hasattr(self,'gps'):
+                current["gps"]=collections.OrderedDict()
+                current["gps"]["longitude"]=self.gps.longitude
+                current["gps"]["latitude"]=self.gps.latitude
+
             #logger.debug('123123123123............')
             res = parklot.update_one({'_id': ObjectId(self.pk)},
                                    {'$set': current})

--- a/playground/settings.py
+++ b/playground/settings.py
@@ -115,7 +115,7 @@ TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    os.path.join(os.path.dirname(__file__), '../templates').replace('\\','/'),
+    #os.path.join(os.path.dirname(__file__), '../templates').replace('\\','/'),
 )
 #SITE_ID=1
 


### PR DESCRIPTION
rewrite save method of parklot , let gps sub doc to be OrderedDIct.

This fix brach is for the error caused by 2dsphere index which require
the gps sub doc, longitude locale before latitude. I miss the index
part of the mongo validator import at the  beginning.